### PR TITLE
Persist mermaid theme in localStorage, default to zinc-dark in dark mode

### DIFF
--- a/src/tools/mermaid/index.tsx
+++ b/src/tools/mermaid/index.tsx
@@ -229,13 +229,22 @@ function resolveSvgForRaster(svg: string): string {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export default function MermaidTool() {
+  const { isDark } = useTheme()
   const [code, setCode] = useState(SAMPLES['flowchart']!.code)
-  const [themeName, setThemeName] = useState('zinc-light')
+  const [themeName, setThemeName] = useState(() => {
+    const stored = localStorage.getItem('mermaid-theme')
+    if (stored && stored in THEMES) return stored
+    return isDark ? 'zinc-dark' : 'zinc-light'
+  })
   const [viewMode, setViewMode] = useState<ViewMode>('split')
   const { expanded, setExpanded } = useExpandable()
-  const { isDark } = useTheme()
   const isDarkRef = useRef(isDark)
   isDarkRef.current = isDark
+
+  // ── Persist theme selection ─────────────────────────────────────────────────
+  useEffect(() => {
+    localStorage.setItem('mermaid-theme', themeName)
+  }, [themeName])
 
   const editorContainerRef = useRef<HTMLDivElement>(null)
   const editorViewRef = useRef<EditorView | null>(null)

--- a/src/tools/mermaid/index.tsx
+++ b/src/tools/mermaid/index.tsx
@@ -241,10 +241,11 @@ export default function MermaidTool() {
   const isDarkRef = useRef(isDark)
   isDarkRef.current = isDark
 
-  // ── Persist theme selection ─────────────────────────────────────────────────
+  // ── Auto-follow dark mode when the user has no stored preference ─────────────
   useEffect(() => {
-    localStorage.setItem('mermaid-theme', themeName)
-  }, [themeName])
+    if (localStorage.getItem('mermaid-theme')) return
+    setThemeName(isDark ? 'zinc-dark' : 'zinc-light')
+  }, [isDark])
 
   const editorContainerRef = useRef<HTMLDivElement>(null)
   const editorViewRef = useRef<EditorView | null>(null)
@@ -448,7 +449,7 @@ export default function MermaidTool() {
                   <Select
                     options={THEME_OPTIONS}
                     value={themeName}
-                    onChange={e => setThemeName(e.target.value)}
+                    onChange={e => { localStorage.setItem('mermaid-theme', e.target.value); setThemeName(e.target.value) }}
                     className="h-7 text-xs py-0"
                   />
                 </div>

--- a/src/tools/mermaid/index.tsx
+++ b/src/tools/mermaid/index.tsx
@@ -280,10 +280,26 @@ export default function MermaidTool() {
   // ── User zoom — null means "auto-fit" ────────────────────────────────────────
   const [userZoom, setUserZoom] = useState<number | null>(null)
   const effectiveScale = userZoom ?? svgScale
+  const svgScaleRef = useRef(svgScale)
+  svgScaleRef.current = svgScale
 
-  const handleZoomIn  = useCallback(() => setUserZoom(z => Math.min(4, (z ?? svgScale) * 1.25)), [svgScale])
-  const handleZoomOut = useCallback(() => setUserZoom(z => Math.max(0.05, (z ?? svgScale) * 0.8)), [svgScale])
+  const handleZoomIn  = useCallback(() => setUserZoom(z => Math.min(4, (z ?? svgScaleRef.current) * 1.25)), [])
+  const handleZoomOut = useCallback(() => setUserZoom(z => Math.max(0.05, (z ?? svgScaleRef.current) * 0.8)), [])
   const handleZoomFit = useCallback(() => setUserZoom(null), [])
+
+  // ── Trackpad pinch-to-zoom ────────────────────────────────────────────────────
+  useEffect(() => {
+    const el = previewPaneRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return
+      e.preventDefault()
+      const factor = Math.exp(-e.deltaY * 0.01)
+      setUserZoom(z => Math.min(4, Math.max(0.05, (z ?? svgScaleRef.current) * factor)))
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [])
 
   // ── Esc handled by useExpandable ────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Theme selection is now saved to `localStorage` (`mermaid-theme` key) and restored on next visit
- On first visit with no stored preference, defaults to `zinc-dark` when the app is in dark mode, `zinc-light` otherwise
- Stored preference always wins — toggling dark mode won't override an explicit user selection

https://claude.ai/code/session_01E39NnaoKp82x2sKFJ97nJh

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist the Mermaid theme via `localStorage`, auto-following dark mode until the user picks a theme. Adds smooth Ctrl+wheel pinch-to-zoom in the preview with clamped scaling.

- **New Features**
  - Save theme as `mermaid-theme`; restore on load. No stored value => `zinc-dark` in dark mode, `zinc-light` otherwise. Only persist on explicit selection; user choice overrides dark mode.
  - Trackpad pinch-to-zoom (Ctrl + wheel) with smooth exponential scaling, clamped to 5%–400%; works with zoom in/out/fit.

<sup>Written for commit ec3e9d40db41bbbbc184a86aa37de186b858c5ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pinch/Control+scroll zooming for the diagram preview pane.

* **Improvements**
  * Theme selection is now persisted and restored across visits.
  * Dark mode can automatically follow the app/system when no theme is set.
  * Zoom controls are more responsive and stable, reducing occasional stale behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->