### PR TITLE
Add Escape and Unescape buttons to JSON Formatter tool

### DIFF
--- a/src/tools/json-formatter/index.tsx
+++ b/src/tools/json-formatter/index.tsx
@@ -235,11 +235,22 @@ export default function JsonFormatterTool() {
   const handleUnescape = () => {
     const text = currentText;
     if (!text) return;
+    // Case 1: text is a quoted JSON string, e.g. "{\"type\":\"foo\"}"
+    try {
+      const parsed = JSON.parse(text);
+      if (typeof parsed === 'string') {
+        setEditorContent(parsed);
+        return;
+      }
+    } catch {
+      // not a quoted JSON string, fall through
+    }
+    // Case 2: text is escaped content without surrounding quotes, e.g. hello\\nworld
     try {
       const unescaped = JSON.parse('"' + text + '"') as string;
       setEditorContent(unescaped);
     } catch {
-      setValidState("invalid");
+      // already unescaped or not escape-encoded — do nothing silently
     }
   };
 

--- a/src/tools/json-formatter/index.tsx
+++ b/src/tools/json-formatter/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Braces, AlignLeft, ChevronsLeftRight, CircleCheck, RefreshCw, Trash2, ListFilter, Play, X, HelpCircle } from "lucide-react";
+import { Braces, AlignLeft, ChevronsLeftRight, CircleCheck, RefreshCw, Trash2, ListFilter, Play, X, HelpCircle, Quote } from "lucide-react";
 import { basicSetup } from "codemirror";
 import { EditorView } from "@codemirror/view";
 import { EditorState, Compartment } from "@codemirror/state";
@@ -225,6 +225,24 @@ export default function JsonFormatterTool() {
     setValidState(result.valid ? "valid" : "invalid");
   };
 
+  const handleEscape = () => {
+    const text = currentText;
+    if (!text) return;
+    const escaped = JSON.stringify(text).slice(1, -1);
+    setEditorContent(escaped);
+  };
+
+  const handleUnescape = () => {
+    const text = currentText;
+    if (!text) return;
+    try {
+      const unescaped = JSON.parse('"' + text + '"') as string;
+      setEditorContent(unescaped);
+    } catch {
+      setValidState("invalid");
+    }
+  };
+
   const handleClear = () => {
     setEditorContent("");
     setValidState("idle");
@@ -292,6 +310,14 @@ export default function JsonFormatterTool() {
                    <ListFilter className="w-3 h-3" />
                    Filter
                  </Button>
+                <Button variant="secondary" size="sm" onClick={handleEscape} className="gap-1.5 text-xs h-7 px-3">
+                  <Quote className="w-3 h-3" />
+                  Escape
+                </Button>
+                <Button variant="secondary" size="sm" onClick={handleUnescape} className="gap-1.5 text-xs h-7 px-3">
+                  <Quote className="w-3 h-3" />
+                  Unescape
+                </Button>
 
                 {validState === "valid" && (
                   <Badge variant="success" className="text-[10px] animate-fade-in">Valid JSON</Badge>

--- a/src/tools/json-formatter/meta.ts
+++ b/src/tools/json-formatter/meta.ts
@@ -6,7 +6,7 @@ export const meta: ToolMeta = {
   name: 'JSON Formatter',
   description: 'Prettify, minify, and validate JSON with inline error highlighting',
   category: 'Formatting',
-  keywords: ['json', 'format', 'prettify', 'minify', 'validate', 'lint', 'formatter', 'beautify', 'parse'],
+  keywords: ['json', 'format', 'prettify', 'minify', 'validate', 'lint', 'formatter', 'beautify', 'parse', 'escape', 'unescape'],
   path: '/json',
   icon: Braces,
 }


### PR DESCRIPTION
Adds two new in-place operations:
- Escape: converts raw text to a JSON-escaped string (e.g. newlines → \n, quotes → \")
- Unescape: reverses JSON string escaping back to raw text

Also adds 'escape' and 'unescape' to the tool's search keywords.

https://claude.ai/code/session_01NQzqHi3HnGe9ov9xpEzBwe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Escape and Unescape to the JSON Formatter so you can switch between raw text and JSON-escaped strings in place. Unescape now supports quoted strings and safely no-ops on already unescaped text.

- **New Features**
  - Escape: convert current text to a JSON-escaped string (e.g., newlines → \n, quotes → \").
  - Unescape: decode quoted JSON strings or bare escaped text to raw; no error on already-unescaped or unparseable input.
  - Added search keywords: escape, unescape.

<sup>Written for commit 603ec6ac0af08854732586e9aae52a9841b7a827. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Escape and Unescape buttons to the JSON formatter. Use Escape to convert text into properly escaped JSON strings, and Unescape to decode escaped JSON strings back to original text.
  * Unescape will leave content unchanged if decoding fails, so some inputs may not be transformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->