### PR TITLE
feat(jwt-decoder): Pretty-print JSON payload values

### DIFF
--- a/src/__tests__/jwt.test.ts
+++ b/src/__tests__/jwt.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { decodeJWT, formatTimestamp, isExpired } from '../tools/jwt-decoder/logic'
+import { decodeJWT, formatPayloadValue, formatTimestamp, isExpired } from '../tools/jwt-decoder/logic'
 
 // Encode a plain object to base64url (no padding)
 function b64url(obj: unknown): string {
@@ -66,6 +66,18 @@ describe('decodeJWT', () => {
     const result = decodeJWT(token)
     expect(typeof result.payload.exp).toBe('number')
     expect(typeof result.payload.iat).toBe('number')
+  })
+})
+
+describe('formatPayloadValue', () => {
+  it('pretty-prints JSON encoded as a string', () => {
+    expect(formatPayloadValue('{"user":{"name":"Ada"},"roles":["admin"]}')).toBe(
+      '{\n  "user": {\n    "name": "Ada"\n  },\n  "roles": [\n    "admin"\n  ]\n}',
+    )
+  })
+
+  it('keeps ordinary string values unchanged', () => {
+    expect(formatPayloadValue('Ada Lovelace')).toBe('Ada Lovelace')
   })
 })
 

--- a/src/tools/jwt-decoder/index.tsx
+++ b/src/tools/jwt-decoder/index.tsx
@@ -9,7 +9,7 @@ import { SectionLabel } from '../../components/ui/SectionLabel'
 import { Alert } from '../../components/ui/Alert'
 import { FlowDivider } from '../../components/ui/FlowDivider'
 import { ClipboardList, Info, LockKeyhole, ShieldCheck, Trash2 } from 'lucide-react'
-import { type DecodedJWT, decodeJWT, formatTimestamp, isExpired } from './logic'
+import { type DecodedJWT, decodeJWT, formatPayloadValue, formatTimestamp, isExpired } from './logic'
 
 const KNOWN_CLAIMS: Record<string, string> = {
   iss: 'Issuer',
@@ -171,8 +171,8 @@ export default function JwtDecoderTool() {
                           </span>
                         )}
                       </div>
-                      <div className="text-xs font-mono text-[var(--color-ink)] break-all">
-                        {typeof value === 'object' ? JSON.stringify(value) : String(value)}
+                      <div className="text-xs font-mono text-[var(--color-ink)] whitespace-pre-wrap break-all">
+                        {formatPayloadValue(value)}
                         {TIME_CLAIMS.includes(key) && formatTimestamp(value) && (
                           <span className="text-[var(--color-ink-muted)] ml-2">
                             ({formatTimestamp(value)})

--- a/src/tools/jwt-decoder/logic.ts
+++ b/src/tools/jwt-decoder/logic.ts
@@ -40,6 +40,26 @@ export function decodeJWT(token: string): DecodedJWT {
   }
 }
 
+export function formatPayloadValue(value: unknown): string {
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value)
+      if (parsed !== null && typeof parsed === 'object') {
+        return JSON.stringify(parsed, null, 2)
+      }
+    } catch {
+      // Keep ordinary string claims unchanged.
+    }
+    return value
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return JSON.stringify(value, null, 2)
+  }
+
+  return String(value)
+}
+
 export function formatTimestamp(value: unknown): string | null {
   if (typeof value !== 'number') return null
   const date = new Date(value * 1000)


### PR DESCRIPTION
# Summary
- Detect JSON object and array values stored as strings in JWT payloads.
- Render those values as formatted, readable JSON.
- Preserve ordinary string payload values unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pretty-print JSON values in JWT payloads to make nested data easier to read. Detects objects/arrays stored as strings and formats them, while keeping ordinary strings unchanged.

- **New Features**
  - Added `formatPayloadValue` to parse stringified JSON and pretty-print objects/arrays.
  - Updated decoder UI to use `formatPayloadValue` and `whitespace-pre-wrap` for multi-line values.
  - Added tests covering pretty-printed JSON and unchanged plain strings.

<sup>Written for commit b48f7ebef7e1e49f91137d674aaee4ccbea78535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/midplane/utils.foo/pull/22?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved JWT payload formatting for clearer, more readable claim values.
  * JSON content is now displayed with indentation and line breaks, while plain text remains unchanged.

* **Bug Fixes**
  * Improved payload rendering to preserve whitespace and wrap long values for easier viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->